### PR TITLE
Remove django-debug-toolbar entirely

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -9,7 +9,6 @@ django-haystack
 psycopg2
 celery
 redis
-django-debug-toolbar
 django-celery
 django-celery-email
 pep8

--- a/skeleton/settings.py
+++ b/skeleton/settings.py
@@ -144,7 +144,6 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'djcelery',
     'djcelery_email',
-    'debug_toolbar',
 
     # sample apps to explain usage
     'app1',
@@ -196,12 +195,6 @@ CELERY_IMPORTS = ('celery_app.tasks',)
 EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
 if DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-# Django debug toolbar
-DEBUG_TOOLBAR_CONFIG = {
-    'INTERCEPT_REDIRECTS': False,
-    'ENABLE_STACKTRACES': True,
-}
 
 # South configuration variables
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'


### PR DESCRIPTION
Aside from just really seriously being a turd, turns out django-debug-toolbar (the very presence of it's package in a VE) is also causing Celery memory leaks in production due to the way it hooks and then consequently completely fucks up logging.

We should remove it entirely everywhere, if people want to use it for dev they can just configure via their dev local settings.
